### PR TITLE
Replace link for "From Interpretation to Compilation"

### DIFF
--- a/done.md
+++ b/done.md
@@ -842,7 +842,7 @@ This paper gives a concise technical overview of some of the more interesting
 VM techniques employed in the Lua interpreter. Lua is probably my favorite VM to
 look at, and the authors do a pretty great job at explaining why that is.
 
-* [From Interpretation to Compilation](ftp://ftp.cs.ru.nl/pub/Clean/papers/2008/janj08-CEFP07-InterpretationToCompilation.pdf) by **Jan Jansen et al.** (2008)
+* [From Interpretation to Compilation](https://www.mbsd.cs.ru.nl/publications/papers/2008/janj08-CEFP07-InterpretationToCompilation.pdf) by **Jan Jansen et al.** (2008)
 
 This paper is quite useful as a reference for people wanting to build compilers
 for functional languages; it shows a few implementation techniques that might


### PR DESCRIPTION
The previous link used FTP, which does not show up as a click-able link when rendered with Github flavoured markdown. The replacement link, [obviously 💙] still links to the same paper, and is hosted by the same university, but is an HTTP accessible link instead (which visitors can click on).

Before:

![image](https://user-images.githubusercontent.com/5955761/96268755-f7292500-0fb8-11eb-88a4-c9c339856835.png)

After:

![image](https://user-images.githubusercontent.com/5955761/96268814-09a35e80-0fb9-11eb-9364-1c8cc2d9bf2a.png)

